### PR TITLE
Created netlify.toml file to fix the Not found error

### DIFF
--- a/public/netlify.toml
+++ b/public/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
The `Not found error` issue for netlify deployment has been fixed with the `netlify.toml` file with its content redirecting correctly as shown below:

```
[[redirects]]
  from = "/*"
  to = "/index.html"
  status = 200
```